### PR TITLE
Update notebooks to 1.0.10

### DIFF
--- a/Training_and_inference_on_an_example_dataset.ipynb
+++ b/Training_and_inference_on_an_example_dataset.ipynb
@@ -122,7 +122,7 @@
         "colab": {}
       },
       "source": [
-        "!python3 -m pip install sleap"
+        "!pip install sleap==1.0.10"
       ],
       "execution_count": 0,
       "outputs": []
@@ -206,7 +206,7 @@
         "colab": {}
       },
       "source": [
-        "!sleap-train baseline.topdown_confmaps.json \"dataset/drosophila-melanogaster-courtship/courtship_labels.slp\" --run_name \"courtship.topdown_confmaps\" --video-paths \"dataset/drosophila-melanogaster-courtship/20190128_113421.mp4\""
+        "!sleap-train baseline_medium_rf.topdown.json \"dataset/drosophila-melanogaster-courtship/courtship_labels.slp\" --run_name \"courtship.topdown_confmaps\" --video-paths \"dataset/drosophila-melanogaster-courtship/20190128_113421.mp4\""
       ],
       "execution_count": 0,
       "outputs": []

--- a/Training_and_inference_using_Google_Drive.ipynb
+++ b/Training_and_inference_using_Google_Drive.ipynb
@@ -106,7 +106,7 @@
         "colab": {}
       },
       "source": [
-        "!python3 -m pip install sleap"
+        "!pip install sleap==1.0.10"
       ],
       "execution_count": 0,
       "outputs": []
@@ -199,7 +199,7 @@
         "colab": {}
       },
       "source": [
-        "!sleap-train baseline.bottomup.json colab.pkg.slp --run_name \"colab_demo.bottomup\""
+        "!sleap-train baseline_medium_rf.bottomup.json colab.pkg.slp --run_name \"colab_demo.bottomup\""
       ],
       "execution_count": 0,
       "outputs": []
@@ -238,7 +238,7 @@
         "colab": {}
       },
       "source": [
-        "!sleap-train baseline.topdown_confmaps.json colab.pkg.slp --run_name \"colab_demo.topdown_confmaps\""
+        "!sleap-train baseline_medium_rf.topdown.json --run_name \"colab_demo.topdown_confmaps\""
       ],
       "execution_count": 0,
       "outputs": []

--- a/Training_with_custom_hyperparameters.ipynb
+++ b/Training_with_custom_hyperparameters.ipynb
@@ -105,7 +105,7 @@
         "colab": {}
       },
       "source": [
-        "!python3 -m pip install sleap"
+        "!pip install sleap==1.0.10"
       ],
       "execution_count": 0,
       "outputs": []


### PR DESCRIPTION
Update notebooks to SLEAP 1.0.10.

- Add explicit version in pip install.
- Fix baseline profile names.

Fixes #3.